### PR TITLE
Resource reading for standalone .c file fix

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lt64-asm "0.0.3"
+(defproject lt64-asm "0.0.3-1"
   :description "Assembler for the lieutenant-64 virtual machine"
   :url "https://github.com/strinsberg/lt64-asm"
   :dependencies [[org.clojure/clojure "1.10.1"]

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,6 @@
-(defproject lt64-asm "0.0.3-SNAPSHOT"
+(defproject lt64-asm "0.0.3"
   :description "Assembler for the lieutenant-64 virtual machine"
   :url "https://github.com/strinsberg/lt64-asm"
-  :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
-            :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.clojure/tools.cli "1.0.206"]]
   :main ^:skip-aot lt64-asm.core

--- a/src/lt64_asm/files.clj
+++ b/src/lt64_asm/files.clj
@@ -2,6 +2,7 @@
   (:require 
     [lt64-asm.symbols :as sym]
     [lt64-asm.stdlib :as stdlib]
+    [clojure.java.io :as jio]
     [clojure.edn :as edn]))
 
 ;; Load ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -122,7 +123,7 @@
   and program, but allows easier portability of the program."
   [program-bytes path]
   (spit path
-        (str (slurp "resources/lt64.c")
+        (str (slurp (jio/resource "lt64.c"))
              (wrap-prog program-bytes))))
 
 ;; REPL ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
The way that resources were being read to create a standalone .c file was incorrect for creating an uberjar. As a result the standalone uberjar failed to run properly for the `-c` option. This patch fixes this so that it works as expected.